### PR TITLE
Bring back appdata file

### DIFF
--- a/org.audacityteam.Audacity.appdata.xml
+++ b/org.audacityteam.Audacity.appdata.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.audacityteam.Audacity</id>
+  <launchable type="desktop-id">audacity.desktop</launchable>
+  <project_license>GPL-2.0 and CC-BY-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Audacity</name>
+  <summary>Record and edit audio files</summary>
+  <description>
+    <p>Audacity® is a free, easy-to-use, multi-track audio editor and recorder for Windows, Mac OS X, GNU/Linux and other operating systems. The interface is translated into many languages.</p>
+    <p>You can use Audacity to:</p>
+    <ul>
+      <li>Record live audio</li>
+      <li>Convert tapes and records into digital recordings or CDs</li>
+      <li>Edit WAV, AIFF, FLAC, MP2, MP3 or Ogg Vorbis sound files</li>
+      <li>Cut, copy, splice or mix sounds together</li>
+      <li>Change the speed or pitch of a recording</li>
+      <li>Apply a wide range of other effects to audio recordings</li>
+    </ul>
+  </description>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Audio</category>
+  </categories>
+  <content_rating type="oars-1.1" />
+  <url type="homepage">https://www.audacityteam.org/</url>
+  <url type="bugtracker">https://bugzilla.audacityteam.org/</url>
+  <url type="faq">https://manual.audacityteam.org/man/faq.html</url>
+  <url type="help">https://manual.audacityteam.org/</url>
+  <url type="donation">https://www.audacityteam.org/donate/</url>
+  <url type="translate">https://www.audacityteam.org/community/translators/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://www.audacityteam.org/wp-content/uploads/2016/01/audacity-212-linux.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://www.audacityteam.org/wp-content/uploads/2015/11/Audacity-2-2-0-on-Linux.png</image>
+    </screenshot>
+  </screenshots>
+  <update_contact>audacity-devel@lists.sourceforge.net</update_contact>
+  <releases>
+    <release version="2.3.0" date="2018-09-29">
+     <description>
+        <p>New features in Audacity 2.3.0:</p>
+        <ul>
+          <li>New feature – Punch and Roll Recording.</li>
+          <li>Pinned-play-head can now be repositioned by dragging.</li>
+          <li>Play-at-speed now can be adjusted whilst playing.</li>
+          <li>Toolbars controlling volume and speed can now be resized for greater precision.</li>
+          <li>Macros (formerly Chains) substantially extended.</li>
+          <li>New Tools menu.</li>
+          <li>New Scriptables commands.</li>
+          <li>Nyquist gains AUD-DO command.</li>
+          <li>Nyquist effects are now translatable and translated.</li>
+          <li>More dialogs have help buttons now.</li>
+          <li>Increased legibility of trackname display.</li>
+          <li>Half-wave option for collapsed tracks.</li>
+          <li>Sliding Stretch.</li>
+          <li>Dialog (option) for entering labels.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -5,7 +5,6 @@ runtime-version: '18.08'
 sdk: org.freedesktop.Sdk
 command: audacity
 rename-desktop-file: audacity.desktop
-rename-appdata-file: audacity.appdata.xml
 rename-icon: audacity
 finish-args:
   - --share=ipc
@@ -163,10 +162,15 @@ modules:
     post-install:
       - chrpath -d /app/bin/audacity
       - mv /app/share/mime/packages/audacity.xml /app/share/mime/packages/org.audacityteam.Audacity.xml
+      - rm -rf /app/share/appdata
+      - install -Dm644 -t /app/share/metainfo org.audacityteam.Audacity.appdata.xml
+      - sed -i s/audacity.desktop/org.audacityteam.Audacity.desktop/ /app/share/metainfo/org.audacityteam.Audacity.appdata.xml
     cleanup:
       - /share/audacity/include
       - /share/pixmaps
     sources:
+      - type: file
+        path: org.audacityteam.Audacity.appdata.xml
       - type: archive
         url: https://github.com/audacity/audacity/archive/Audacity-2.3.0.tar.gz
         sha256: 37127f68dceeb5da08d008ec9373a65e2d5d0a9b937c808a5d7c3b88aa9e275e


### PR DESCRIPTION
Reinstate the Flathub copy of the appdata file for now:
 - Include a new copy from upstream, which adds release notes for 2.3.0 (added
   after the fact) and critically, sets the component type to desktop
 - Also include my PR https://github.com/audacity/audacity/pull/324 to correct
   the launchable type syntax and add the OARS ratings back
 - Substitute the launchable desktop ID to the correct app ID

With the upstream file shipped in 2.3.0, GNOME Software can't match the
.desktop file installed with the <component type="generic"> in the Flathub
appstream, so the app appears twice - one you can upgrade and one you can
launch.