### PR TITLE
Upgrade freedesktop runtime to 20.08

### DIFF
--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -1,7 +1,7 @@
 app-id: org.audacityteam.Audacity
 default-branch: stable
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 command: audacity
 rename-desktop-file: audacity.desktop


### PR DESCRIPTION
ALSA support is better in 20.08. 

JACK support may work (but I haven't been able to make it work with Audacity through pipewire yet)