### PR TITLE
Update to audacity 3.0.0

### DIFF
--- a/audacity-suil-fix.patch
+++ b/audacity-suil-fix.patch
@@ -11,37 +11,14 @@ index 289688eb9..f998a0805 100644
     set( SUIL_GTK2_LIB_NAME "libgtk-x11-2.0.so.0" )
     set( SUIL_GTK3_LIB_NAME "libgtk-x11-3.0.so.0" )
     set( SUIL_MODULE_PREFIX "lib" )
-@@ -215,27 +215,27 @@ elseif( UNIX )
-    pkg_check_modules( QT4 IMPORTED_TARGET "QtGui >= 4.4.0" )
-    pkg_check_modules( QT5 IMPORTED_TARGET "Qt5Widgets >= 5.1.0" )
+--- a/src/CMakeLists.txt	2021-03-18 22:59:02.577128541 -0400
++++ b/src/CMakeLists.txt	2021-03-18 22:59:29.260332383 -0400
+@@ -1073,7 +1073,7 @@
  
--   bld( "suil_x11"
-+   bld( "libsuil_x11"
-         "X11"
-         "SUIL_WITH_X11"
-         "${TARGET_ROOT}/suil/src/x11.c" )
--   bld( "suil_x11_in_gtk2"
-+   bld( "libsuil_x11_in_gtk2"
-         "X11;GTK2X11"
-         "SUIL_WITH_X11_IN_GTK2"
-         "${TARGET_ROOT}/suil/src/x11_in_gtk2.c" )
--   bld( "suil_x11_in_gtk3"
-+   bld( "libsuil_x11_in_gtk3"
-         "X11;GTK3X11"
-         "SUIL_WITH_X11_IN_GTK3"
-         "${TARGET_ROOT}/suil/src/x11_in_gtk3.c" )
--   bld( "suil_qt4_in_gtk2"
-+   bld( "libsuil_qt4_in_gtk2"
-         "QT4;GTK2"
-         "SUIL_WITH_QT4_IN_GTK2"
-         "${TARGET_ROOT}/suil/src/qt4_in_gtk2.cpp" )
--   bld( "suil_qt5_in_gtk2"
-+   bld( "libsuil_qt5_in_gtk2"
-         "QT5;GTK2"
-         "SUIL_WITH_QT5_IN_GTK2"
-         "${TARGET_ROOT}/suil/src/qt5_in_gtk.cpp" )
--   bld( "suil_qt5_in_gtk3"
-+   bld( "libsuil_qt5_in_gtk3"
-         "QT5;GTK3"
-         "SUIL_WITH_QT5_IN_GTK3"
-         "${TARGET_ROOT}/suil/src/qt5_in_gtk.cpp" )
+ set( BUILDING_AUDACITY YES )
+ set( INSTALL_PREFIX "${_PREFIX}" )
+-set( PKGLIBDIR "${_PKGLIBDIR}" )
++set( PKGLIBDIR "${_PKGLIB}" )
+ set( LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}" )
+ set( HAVE_GTK ${GTK_FOUND} )
+ 

--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -42,13 +42,12 @@ cleanup:
   - '*.a'
 modules:
 
-  - shared-modules/python2.7/python-2.7.json
-
   - name: wxwidgets
     rm-configure: true
     config-opts:
       - --with-libpng
       - --with-zlib
+      - --with-cxx=14
       - --disable-sdltest
       - --disable-webkit
       - --disable-webview
@@ -63,9 +62,10 @@ modules:
       - /lib/wx
       - /share/bakefile
     sources:
-      - type: archive # HiDPI is broken in v3.1
-        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2
-        sha256: 440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807
+      - type: git # they want their fork
+        url: https://github.com/audacity/wxWidgets
+        # branch: audacity-fixes-3.1.3
+        commit: 07e7d832c7a337aedba3537b90b2c98c4d8e2985
 
   - name: ffmpeg
     config-opts:
@@ -141,10 +141,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/audacity/audacity.git
-        commit: 16d52f63a4183bba77ef7305d14622958dc0d1d5
-        tag: Audacity-2.4.2
+        commit: d5d4c46a3f6ae59e63ec79336def5139dbf04f48
+        tag: Audacity-3.0.0
       - type: patch
         path: audacity-suil-fix.patch
       - type: shell
         commands:
-          - sed -e '42i <release version="2.4.2" date="2020-06-26"/>' -i help/audacity.appdata.xml
+          - sed -e '42i <release version="3.0.0" date="2021-03-17"/>' -i help/audacity.appdata.xml


### PR DESCRIPTION
This would replace #59 as it fixes the lv2 support patch.

Closes #59 
Closes #60 

Closes #52 as the audacity fork is used.
