### PR TITLE
Enable SQLITE_DBPAGE virtual table (fixes #62)

### DIFF
--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -118,6 +118,23 @@ modules:
         url: https://www.ffmpeg.org/releases/ffmpeg-4.2.3.tar.xz
         sha256: 9df6c90aed1337634c1fb026fb01c154c29c82a64ea71291ff2da9aacb9aad31
 
+  - name: sqlite
+    # version bundled with runtime is missing the SQLITE_DBPAGE virtual table
+    build-options:
+      cflags: >
+        -DSQLITE_ENABLE_COLUMN_METADATA=1
+        -DSQLITE_SECURE_DELETE=1
+        -DSQLITE_ENABLE_FTS3=1
+        -DSQLITE_ENABLE_UNLOCK_NOTIFY=1
+        -DSQLITE_ENABLE_DBPAGE_VTAB=1
+        -DSQLITE_ENABLE_DBSTAT_VTAB=1
+    config-opts:
+      - --enable-fts5
+    sources:
+      - type: archive
+        url: https://www.sqlite.org/2020/sqlite-autoconf-3340000.tar.gz
+        sha256: bf6db7fae37d51754737747aaaf413b4d6b3b5fbacd52bdb2d0d6e5b2edd9aee
+
   - name: chrpath
     cleanup:
       - '*'


### PR DESCRIPTION
The version of SQLite bundled with the runtime is missing the SQLITE_DBPAGE virtual table.