### PR TITLE
Allow network access for IPC (Fixes #64)

### DIFF
--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -12,6 +12,7 @@ rename-appdata-file: audacity.appdata.xml
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --share=network # Audacity uses network sockets for IPC
   - --socket=pulseaudio
   - --device=all # ALSA
   - --filesystem=host


### PR DESCRIPTION
Audacity uses TCP/IP network sockets to communicate with an already running instance. This obviously fails when network access is blocked and causes the error message "An unrecoverable error has occurred during startup".
To detect if another instance is running in the first place and to exchange TCP port numbers System V IPC is used, which is already allowed: https://github.com/flathub/org.audacityteam.Audacity/blob/4e0b0f309245556383161422337cd916290e9f32/org.audacityteam.Audacity.yaml#L13

Ideally this should be fixed upstream by using unix domain sockets as the [wxWidgets documentation](https://docs.wxwidgets.org/trunk/classwx_client.html#a6ca1cef89e834a724d34edf9872f545d) advises:

> Using Internet domain sockets is extremely insecure for IPC as there is absolutely no access control for them, use Unix domain sockets whenever possible! 