### PR TITLE
Add permission to /tmp for mod-script-pipe named pipes

### DIFF
--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -16,6 +16,8 @@ finish-args:
   - --socket=pulseaudio
   - --device=all # ALSA
   - --filesystem=host
+  # mod-script-pipe provides named pipes in /tmp
+  - --filesystem=/tmp
   - --env=ALSA_CONFIG_PATH=
   - --env=LADSPA_PATH=/app/extensions/Plugins/ladspa
   - --env=LV2_PATH=/app/extensions/Plugins/lv2


### PR DESCRIPTION
- Audacity's mod-script-pipe module provides named pipes at locations
such as
/tmp/audacity_script_pipe.from.1000
/tmp/audacity_script_pipe.to.1000
This allows scripts to interact with audacity.
- When mod-script-pipe is Enabled and Audacity is restarted, these
files are created. But they are merely inside the flatpak container,
not available to the host where they are needed.
- Allow read-write access to /tmp so these files can be provided.