### PR TITLE
use upstream wxWidgets

### DIFF
--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -57,7 +57,6 @@ modules:
       - --with-zlib
       - --with-cxx=14
       - --disable-sdltest
-      - --disable-webkit
       - --disable-webview
       - --disable-webviewwebkit
       - --disable-ribbon
@@ -70,11 +69,9 @@ modules:
       - /lib/wx
       - /share/bakefile
     sources:
-      - type: git # they want their fork
-        url: https://github.com/audacity/wxWidgets
-        # branch: audacity-fixes-3.1.3
-        tag: v3.1.3.1-audacity
-        commit: e42d7f73652cf7e40058a48177a86e0f864ec464
+      - type: git
+        url: https://github.com/wxWidgets/wxWidgets.git
+        tag: v3.1.5
 
   - deps/lame-3.100.json
   - deps/libid3tag/libid3tag.json


### PR DESCRIPTION
This attempts to fix https://github.com/flathub/org.audacityteam.Audacity/issues/85 by using the upstream widget repo. I am adding a couple of minor fixes to it.