### PR TITLE
Issue #139 - Fix the VST

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Flatpak notes
 `LV2_PATH` is set in a wrapper script because variable substitution
 doesn't work.
 
+`VST_PATH` doesn't need to be set we patched the default location in
+the source. See https://github.com/flathub/org.audacityteam.Audacity/issues/139
+
 `patches/audacity-suil-fix.patch` is necessary for suil (LV2 UI) to
 work. A fix was submitted upstream in the past but was ignored.
 This version of the patch is highly specific to flatpak.

--- a/org.audacityteam.Audacity.yaml
+++ b/org.audacityteam.Audacity.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --env=LD_LIBRARY_PATH=/app/lib/audacity
   - --env=ALSA_CONFIG_PATH=
   - --env=LADSPA_PATH=/app/extensions/Plugins/ladspa
-  - --env=VST_PATH=/app/extensions/Plugins/vst
   - --env=VST3_PATH=/app/extensions/Plugins/vst3
   # JACK support via pipewire
   - --filesystem=xdg-run/pipewire-0
@@ -246,6 +245,7 @@ modules:
           - patches/0001-audacity-suil-fix.patch
           - patches/0002-audacity-c++fs.patch
           - patches/0003-audacity-appstream.patch
+          - patches/0004-audacity-vst-path.patch
       - type: git
         dest: vst3sdk
         url: https://github.com/steinbergmedia/vst3sdk.git

--- a/patches/0004-audacity-vst-path.patch
+++ b/patches/0004-audacity-vst-path.patch
@@ -1,0 +1,15 @@
+diff --git a/libraries/lib-vst/VSTEffectsModule.cpp b/libraries/lib-vst/VSTEffectsModule.cpp
+index 88f11746d..b2c22ab94 100644
+--- a/libraries/lib-vst/VSTEffectsModule.cpp
++++ b/libraries/lib-vst/VSTEffectsModule.cpp
+@@ -238,8 +238,8 @@ PluginPaths VSTEffectsModule::FindModulePaths(PluginManagerInterface & pm)
+       pathList.push_back(wxT(LIBDIR) wxT("/vst"));
+ 
+       // These are the defaults used by other hosts
+-      pathList.push_back(wxT("/usr/lib/vst"));
+-      pathList.push_back(wxT("/usr/local/lib/vst"));
++      // Flatpak default
++      pathList.push_back(wxT("/app/extensions/Plugins/vst"));
+       pathList.push_back(wxGetHomeDir() + wxFILE_SEP_PATH + wxT(".vst"));
+    }
+ 


### PR DESCRIPTION
- use the upstream behaviour by harcoding the flatpak path with a patch
- overriding VST_PATH will work the same, ie override the defaults
- defaults include ~/.vst


Close #139 